### PR TITLE
Typo: param should be `embed` not `embedded`

### DIFF
--- a/short_urls.py
+++ b/short_urls.py
@@ -51,7 +51,7 @@ def get_embed_code_from_hash(hash: str):
         width="100%"
         height="500px"
         frameBorder="0"
-        src="{BASE_URL}/~/+/?embedded=true&q={hash}">
+        src="{BASE_URL}/~/+/?embed=true&q={hash}">
     </iframe>
     """
     )


### PR DESCRIPTION
I'm unsure if `embedded` does anything currently on Community Cloud, but IIUC the param name was switched to `embed`. 

Source: [Embed your app](https://docs.streamlit.io/streamlit-community-cloud/share-your-app/embed-your-app#embedding-with-iframes)